### PR TITLE
Update permissions to create mvn dependency graph

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@
 name: Java CI with Maven
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 on:
@@ -20,9 +20,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17
@@ -33,7 +31,6 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn clean package
-
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@v4


### PR DESCRIPTION
Set contents permission to `write`

https://github.com/advanced-security/maven-dependency-submission-action

> This action writes informations in the repository dependency graph, so if you are using the default token, you need to set the contents: write permission to the workflow or job. If you are using a personal access token, this token must have the repo scope. ([API used by this action](https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository))