### PR TITLE
Remove vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
           <type>pom</type>
           <scope>import</scope>
         </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+          <version>1.3.15</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </dependencyManagement>
 
@@ -95,6 +101,12 @@
             <groupId>org.sonarsource.java</groupId>
             <artifactId>sonar-java-plugin</artifactId>
             <version>${sonar.java.version}</version>
+            <exclusions>
+                 <exclusion>
+                     <groupId>org.apache.tomcat.embed</groupId>
+                     <artifactId>*</artifactId>
+               </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sonarsource.python</groupId>


### PR DESCRIPTION
Dependabot reported vulnerabilities from transitive dependencies
- org.apache.tomcat.embed:tomcat-embed-core 9.0.106 update to 9.0.108
- ch.qos.logback:logback-classic 1.2.9 update first to 1.2.13, then to to 1.3.15

The general strategy to fix these problems in either to exclude the offending packages (if they are unnecessary) or to explicitly upgrade them to the required version. 

This PR
- Excludes org.apache.tomcat.embed:* since we don't need any tomact.embed packages
- Explicitly bumps ch.qos.logback:logback-classic to 1.3.15